### PR TITLE
changes to wms_cfg file in product name and datacube-wms name

### DIFF
--- a/datacube_wms/wms_cfg.py
+++ b/datacube_wms/wms_cfg.py
@@ -77,7 +77,7 @@ layer_cfg = [
                 # Included as a keyword  for the layer
                 "variant": "MSI",
                 # The WMS name for the layer
-                "name": "s2a_ard_granule",
+                "name": "s2a_ard_granule_nbar",
                 # The Datacube name for the associated data product
                 "product_name": "s2a_ard_granule",
                 # The Datacube name for the associated pixel-quality product (optional)
@@ -577,7 +577,7 @@ layer_cfg = [
                 # Included as a keyword  for the layer
                 "variant": "MSI",
                 # The WMS name for the layer
-                "name": "s2a_ard_granule",
+                "name": "s2a_ard_granule_nbar_t",
                 # The Datacube name for the associated data product
                 "product_name": "s2a_ard_granule",
                 # The Datacube name for the associated pixel-quality product (optional)


### PR DESCRIPTION
product_name : 's2_ard_granule'
name : 's2_ard_granule' changed to differentiate between NBAR and NBART now it is for NBAR name : 's2_ard_granule_nbar' and for NBART it is 's2_ard_granule_nbar_t'